### PR TITLE
Feature: Make SideStore ID an OAuth provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # Rust
 /target
 
-# VS Code
+# IDE
 .vscode/
+.idea/
 
 # Environment
 .env
+oauth_config.toml
 storage/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 3
 
 [[package]]
+name = "actix"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba56612922b907719d4a01cf11c8d5b458e7d3dba946d0435f20f58d6795ed2"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix_derive",
+ "bitflags 2.4.1",
+ "bytes",
+ "crossbeam-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "actix-cors"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b340e9cfa5b08690aae90fb61beb44e9b06f44fe3d0f93781aaa58cfba86245e"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
 dependencies = [
  "actix-utils",
  "actix-web",
@@ -59,17 +84,17 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
+checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.3",
- "base64 0.21.2",
- "bitflags 1.3.2",
+ "ahash",
+ "base64 0.21.5",
+ "bitflags 2.4.1",
  "brotli",
  "bytes",
  "bytestring",
@@ -98,12 +123,12 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -121,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
+checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
 dependencies = [
  "futures-core",
  "tokio",
@@ -131,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e8613a75dd50cc45f473cee3c34d59ed677c0f7b44480ce3b8247d7dc519327"
+checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -141,7 +166,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "num_cpus",
  "socket2",
  "tokio",
  "tracing",
@@ -170,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3cb42f9566ab176e1ef0b8b3a896529062b4efc6be0123046095914c4c1c96"
+checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -183,7 +207,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -192,7 +216,6 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "http",
  "itoa",
  "language-tags",
  "log",
@@ -205,20 +228,40 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.21",
+ "time",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
+checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
 dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "actix_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7db3d5a9718568e4cf4a537cfd7070e6e6ff7481510d0237fb529ac850f6d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
 ]
 
 [[package]]
@@ -229,32 +272,22 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -275,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +321,18 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "askama_escape"
@@ -296,6 +347,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,9 +369,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -315,11 +381,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcrypt"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df288bec72232f78c1ec5fe4e8f1d108aa0265476e93097593c803c8c02062a"
+checksum = "28d1c9c15093eb224f0baa400f38fcd713fc1391a6f1c389d886beef146d60a3"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.5",
  "blowfish",
  "getrandom",
  "subtle",
@@ -334,9 +400,20 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -370,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -381,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.4"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -391,38 +468,39 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "bytestring"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
+checksum = "74d80203ea6b29df88012294f62733de21cfeab47f17b41af3a38bc30a03ee72"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -433,25 +511,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cc2b23599e6d7479755f3594285efb3f74a1bdca7a7374948bc831e23a552"
+checksum = "e23185c0e21df6ed832a12e2bda87c7d1def6842881fb634a8511ced741b0d76"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -460,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9998fb9f7e9b2111641485bf8beb32f92945f97f92a3d061f744cfef335f751"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -481,9 +558,15 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -498,21 +581,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.21",
+ "time",
  "version_check",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -524,6 +607,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -547,17 +640,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.2"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "packed_simd_2",
  "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -597,13 +703,22 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -621,11 +736,11 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.1.0"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
+checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.4.1",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -633,27 +748,27 @@ dependencies = [
  "libsqlite3-sys",
  "pq-sys",
  "r2d2",
- "time 0.3.21",
+ "time",
  "uuid",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74398b79d81e52e130d991afeed9c86034bb1b7735f46d2f5bf7deb261d80303"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
 dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "diesel_logger"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a22b1f4804a69ed8954910b2ab30dedc759665e0284e57db95eef4a7b5edffb"
+checksum = "23010b507517129dc9b11fb35f36d76fd2d3dd4c85232733697622e345375f2f"
 dependencies = [
  "diesel",
  "log",
@@ -676,7 +791,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.16",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -692,22 +807,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -718,9 +834,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "ed25519"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
  "signature",
@@ -728,32 +844,33 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-rc.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
  "serde",
  "sha2",
+ "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -770,36 +887,25 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -813,18 +919,18 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -837,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -847,15 +953,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -864,38 +970,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -921,20 +1027,28 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.19"
+name = "gimli"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "h2"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -942,18 +1056,12 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -963,18 +1071,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -993,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1016,9 +1115,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1028,16 +1127,16 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1057,22 +1156,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1082,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
  "serde",
 ]
 
@@ -1096,59 +1185,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.5",
+ "js-sys",
  "pem",
  "ring",
  "serde",
@@ -1164,15 +1242,9 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libredox"
@@ -1180,16 +1252,16 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.4.1",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "pkg-config",
  "vcpkg",
@@ -1197,33 +1269,32 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "local-channel"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
 dependencies = [
  "futures-core",
  "futures-sink",
- "futures-util",
  "local-waker",
 ]
 
 [[package]]
 name = "local-waker"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
+checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1231,18 +1302,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "migrations_internals"
@@ -1251,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -1292,21 +1360,21 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1325,37 +1393,53 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
+name = "object"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
- "hermit-abi 0.2.6",
- "libc",
+ "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "packed_simd_2"
-version = "0.3.8"
+name = "option-ext"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "oxide-auth"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06729d9f5ee0fcade59be20aef48231be773808ea3d2eda2fcac394f678cfd95"
 dependencies = [
- "cfg-if",
- "libm",
+ "base64 0.13.1",
+ "chrono",
+ "hmac",
+ "once_cell",
+ "rand",
+ "rmp-serde",
+ "rust-argon2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "url",
 ]
 
 [[package]]
@@ -1370,15 +1454,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1392,17 +1476,18 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.5",
+ "serde",
 ]
 
 [[package]]
@@ -1416,24 +1501,24 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1441,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1451,18 +1536,18 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1482,15 +1567,21 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "platforms"
-version = "3.0.2"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+checksum = "14e6ab3f592e6fb464fc9712d8d6e6912de6473954635fd76a589d832cffcbb0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1533,18 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1592,15 +1683,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -1621,9 +1703,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1632,23 +1726,56 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5885493fdf0be6cdff808d1533ce878d21cfa49c7086fa00c66355cd9141bfc"
+dependencies = [
+ "base64 0.21.5",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1672,7 +1799,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.16",
+ "syn 2.0.42",
  "walkdir",
 ]
 
@@ -1687,6 +1814,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,23 +1830,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -1735,41 +1867,41 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1778,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -1821,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1832,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1854,10 +1986,11 @@ dependencies = [
 name = "sidestore-id-backend"
 version = "0.1.0"
 dependencies = [
+ "actix",
  "actix-cors",
  "actix-files",
  "actix-web",
- "base64 0.21.2",
+ "base64 0.21.5",
  "bcrypt",
  "chrono",
  "chrono-tz",
@@ -1868,13 +2001,18 @@ dependencies = [
  "dotenvy",
  "ed25519-dalek",
  "env_logger",
+ "futures",
  "jsonwebtoken",
  "log",
+ "oxide-auth",
  "rand",
  "serde",
  "serde_json",
  "testcontainers",
- "time 0.3.21",
+ "time",
+ "tokio",
+ "toml 0.8.10",
+ "url",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -1891,9 +2029,12 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -1904,51 +2045,51 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -1979,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1990,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -2016,42 +2157,33 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
-dependencies = [
+ "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -2059,15 +2191,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -2089,11 +2221,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2106,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2120,32 +2252,57 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2154,11 +2311,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-core",
@@ -2166,39 +2322,39 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -2211,19 +2367,20 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -2232,7 +2389,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -2248,7 +2405,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.16",
+ "syn 2.0.42",
  "uuid",
 ]
 
@@ -2270,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",
@@ -2302,21 +2459,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2324,24 +2475,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2349,32 +2500,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.42",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
-
-[[package]]
-name = "web-sys"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "winapi"
@@ -2394,9 +2535,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -2408,21 +2549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2431,137 +2563,166 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "zerocopy"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"
@@ -2577,18 +2738,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.3+zstd.1.5.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.5+zstd.1.5.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2596,11 +2757,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4.3.1"
+actix = "0.13.1"
+actix-web = "4.4.0"
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
+
+# OAuth2
+oxide-auth = "0.5.4"
+#oxide-auth-actix = "0.2.0"
 
 # A `dotenv` implementation for Rust
 dotenvy = { version = "0.15.7", default-features = false }
@@ -20,18 +25,18 @@ serde_json = "1.0.96"
 # A safe, extensible ORM and Query builder
 diesel = { version = "2.1.0", features = ["chrono", "r2d2", "postgres", "sqlite", "uuid"] }
 diesel_migrations = "2.1.0"
-diesel_logger = { version = "0.2.0", optional = true }
+diesel_logger = { version = "0.3.0", optional = true }
 
 # Hash and verify passwords
-bcrypt = "0.14.0"
+bcrypt = "0.15.0"
 
 # Generate keys for signing reviews
 rand = "0.8.5"
-ed25519-dalek = { version = "2.0.0-rc.2", features = ["alloc", "pkcs8", "pem", "rand_core"] }
+ed25519-dalek = { version = "2.1.0", features = ["alloc", "pkcs8", "pem", "rand_core"] }
 base64 = "0.21.2"
 
 # JWT library
-jsonwebtoken = "8.3.0"
+jsonwebtoken = "9.2.0"
 
 # UUID generation
 uuid = { version = "1.3.3", features = ["serde", "v4"] }
@@ -46,11 +51,15 @@ log = "0.4.17"
 env_logger = "0.10.0"
 
 # Utilities
+tokio = "1.16.1"
+futures = "0.3"
 derive_more = "0.99.17"
+url = "2.5"
 
 # OpenAPI spec
 utoipa = { version = "4", features = ["actix_extras", "uuid", "chrono"] }
 utoipa-swagger-ui = { version = "5", features = ["actix-web"] }
+toml = "0.8.10"
 
 
 [dev-dependencies]

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -8,5 +8,7 @@ JWT_ISSUER="Service Name"
 
 CORS_ORIGIN=*
 
+PUBLIC_URL=https://id.sidestore.io
+
 DATABASE_URL=postgres://user:password@localhost/database
 STORAGE_PATH=/data

--- a/migrations/2024-02-06-205757_add_oauth_authorizations/down.sql
+++ b/migrations/2024-02-06-205757_add_oauth_authorizations/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE oauth_authorizations;

--- a/migrations/2024-02-06-205757_add_oauth_authorizations/up.sql
+++ b/migrations/2024-02-06-205757_add_oauth_authorizations/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE oauth_authorizations
+(
+    user_id    VARCHAR(255) NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    client_id  VARCHAR(255) NOT NULL,
+
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NOT NULL,
+
+    PRIMARY KEY (user_id, client_id)
+)

--- a/oauth_config.sample.toml
+++ b/oauth_config.sample.toml
@@ -1,0 +1,5 @@
+[[clients]]
+client_id = "example-client"
+client_secret = "very-secret-secret"
+scope = "profile"
+redirect_uri = "https://auth.example.com/oauth/callback"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,8 @@
 pub mod auth_controller;
+pub mod oauth2_controller;
 pub mod app_review_controller;
 pub mod ping_controller;
 pub mod models;
+pub mod oauth2;
 pub mod doc;
+pub mod utils;

--- a/src/api/models/mod.rs
+++ b/src/api/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod app_reviews;
+pub mod oauth2;
 
 use serde::{Deserialize, Serialize};
 

--- a/src/api/models/oauth2.rs
+++ b/src/api/models/oauth2.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub enum OAuth2AuthorizationResult {
+    #[serde(rename = "allow")]
+    Allow,
+
+    #[serde(rename = "deny")]
+    Deny,
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthRedirectResponse {
+    pub redirect_url: String
+}

--- a/src/api/oauth2/config.rs
+++ b/src/api/oauth2/config.rs
@@ -1,0 +1,42 @@
+use oxide_auth::primitives::prelude::Client;
+use oxide_auth::primitives::registrar::{ExactUrl, RegisteredUrl};
+use serde::Deserialize;
+
+use crate::auth::JwtTokenScope;
+
+
+#[derive(Debug, Deserialize)]
+pub struct OAuthConfig {
+    pub clients: Vec<OAuthClient>
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OAuthClient {
+    client_id: String,
+    client_secret: String,
+    scope: JwtTokenScope,
+    redirect_uri: String,
+    additional_redirect_uris: Option<Vec<String>>,
+}
+
+impl Into<Client> for &OAuthClient {
+    fn into(self) -> Client {
+        let mut client = Client::confidential(
+            &self.client_id,
+            RegisteredUrl::Exact(ExactUrl::new(self.redirect_uri.to_string()).unwrap()),
+            self.scope.clone().into_oauth_scope().unwrap(),
+            self.client_secret.as_bytes(),
+        );
+
+        if let Some(additional_redirect_urls) = self.additional_redirect_uris.clone() {
+            client = client.with_additional_redirect_uris(
+                additional_redirect_urls
+                    .iter()
+                    .map(|url| RegisteredUrl::Exact(ExactUrl::new(url.to_string()).unwrap()))
+                    .collect()
+            )
+        }
+
+        client
+    }
+}

--- a/src/api/oauth2/mod.rs
+++ b/src/api/oauth2/mod.rs
@@ -1,0 +1,6 @@
+pub mod state;
+pub mod oxide_auth_actix;
+mod operations;
+mod config;
+mod prelude;
+mod token_issuer;

--- a/src/api/oauth2/operations.rs
+++ b/src/api/oauth2/operations.rs
@@ -1,0 +1,98 @@
+use oxide_auth::{
+    endpoint::{
+        AccessTokenFlow, AuthorizationFlow, Endpoint, RefreshFlow, ResourceFlow, ClientCredentialsFlow,
+    },
+    primitives::grant::Grant,
+};
+use super::oxide_auth_actix::{OAuthRequest, OAuthResponse, OAuthOperation, WebError};
+
+/// Authorization-related operations
+pub struct Authorize(pub OAuthRequest);
+
+impl OAuthOperation for Authorize {
+    type Item = OAuthResponse;
+    type Error = WebError;
+
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>,
+    {
+        AuthorizationFlow::prepare(endpoint)?
+            .execute(self.0)
+            .map_err(WebError::from)
+    }
+}
+
+/// Token-related operations
+pub struct Token(pub OAuthRequest);
+
+impl OAuthOperation for Token {
+    type Item = OAuthResponse;
+    type Error = WebError;
+
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>,
+    {
+        AccessTokenFlow::prepare(endpoint)?
+            .execute(self.0)
+            .map_err(WebError::from)
+    }
+}
+
+/// Client Credentials related operations
+pub struct ClientCredentials(pub OAuthRequest);
+
+impl OAuthOperation for ClientCredentials {
+    type Item = OAuthResponse;
+    type Error = WebError;
+
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>,
+    {
+        ClientCredentialsFlow::prepare(endpoint)?
+            .execute(self.0)
+            .map_err(WebError::from)
+    }
+}
+
+/// Refresh-related operations
+pub struct Refresh(pub OAuthRequest);
+
+impl OAuthOperation for Refresh {
+    type Item = OAuthResponse;
+    type Error = WebError;
+
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>,
+    {
+        RefreshFlow::prepare(endpoint)?
+            .execute(self.0)
+            .map_err(WebError::from)
+    }
+}
+
+/// Resource-related operations
+pub struct Resource(pub OAuthRequest);
+
+impl OAuthOperation for Resource {
+    type Item = Grant;
+    type Error = Result<OAuthResponse, WebError>;
+
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>,
+    {
+        ResourceFlow::prepare(endpoint)
+            .map_err(|e| Err(WebError::from(e)))?
+            .execute(self.0)
+            .map_err(|r| r.map_err(WebError::from))
+    }
+}

--- a/src/api/oauth2/oxide_auth_actix.rs
+++ b/src/api/oauth2/oxide_auth_actix.rs
@@ -1,0 +1,473 @@
+//! Bindings and utilities for creating an oauth endpoint with actix.
+//!
+//! Use the provided methods to use code grant methods in an asynchronous fashion, or use an
+//! `AsActor<_>` to create an actor implementing endpoint functionality via messages.
+#![warn(missing_docs)]
+
+use actix::{MailboxError, Message};
+use actix_web::{
+    body::BoxBody,
+    dev::Payload,
+    http::{
+        header::{self, HeaderMap, InvalidHeaderValue},
+        StatusCode,
+    },
+    web::Form,
+    web::Query,
+    FromRequest, HttpRequest, HttpResponse, HttpResponseBuilder, Responder, ResponseError,
+};
+use futures::future::{self, FutureExt, LocalBoxFuture, Ready};
+use oxide_auth::{
+    endpoint::{Endpoint, NormalizedParameter, OAuthError, QueryParameter, WebRequest, WebResponse},
+    frontends::simple::endpoint::Error,
+};
+use std::{borrow::Cow, convert::TryFrom, error, fmt};
+use url::Url;
+
+pub use super::operations::{Authorize, Refresh, Resource, Token, ClientCredentials};
+
+/// Describes an operation that can be performed in the presence of an `Endpoint`
+///
+/// This trait can be implemented by any type, but is very useful in Actor scenarios, where an
+/// Actor can provide an endpoint to an operation sent as a message.
+///
+/// Here's how any Endpoint type can be turned into an Actor that responds to OAuthMessages:
+/// ```rust,ignore
+/// use actix::{Actor, Context, Handler};
+/// use oxide_auth::endpoint::Endpoint;
+/// use oxide_auth_actix::OAuthOperation;
+///
+/// pub struct MyEndpoint {
+///     // Define your endpoint...
+/// }
+///
+/// impl Endpoint<OAuthRequest> for MyEndpoint {
+///     // Implement your endpoint...
+/// }
+///
+/// // Implement Actor
+/// impl Actor for MyEndpoint {
+///     type Context = Context<Self>;
+/// }
+///
+/// // Handle incoming OAuthMessages
+/// impl<Op, Ext> Handler<OAuthMessage<Op, Ext>> for MyEndpoint
+/// where
+///     Op: OAuthOperation,
+/// {
+///     type Result = Result<Op::Item, Op::Error>;
+///
+///     fn handle(&mut self, msg: OAuthMessage<Op, Ext>, _: &mut Self::Context) -> Self::Result {
+///         let (op, _) = msg.into_inner();
+///
+///         op.run(self)
+///     }
+/// }
+/// ```
+///
+/// By additionally specifying a type for Extras, more advanced patterns can be used
+/// ```rust,ignore
+/// type Ext = Option<MyCustomSolicitor>;
+///
+/// // Handle incoming OAuthMessages
+/// impl<Op> Handler<OAuthMessage<Op, Ext>> for MyEndpoint
+/// where
+///     Op: OAuthOperation,
+/// {
+///     type Result = Result<Op::Item, Op::Error>;
+///
+///     fn handle(&mut self, msg: OAuthMessage<Op, Ext>, _: &mut Self::Context) -> Self::Result {
+///         let (op, ext) = msg.into_inner();
+///
+///         op.run(self.with_my_custom_solicitor(ext))
+///     }
+/// }
+/// ```
+pub trait OAuthOperation: Sized + 'static {
+    /// The success-type produced by an OAuthOperation
+    type Item: 'static;
+
+    /// The error type produced by an OAuthOperation
+    type Error: fmt::Debug + 'static;
+
+    /// Performs the oxide operation with the provided endpoint
+    fn run<E>(self, endpoint: E) -> Result<Self::Item, Self::Error>
+    where
+        E: Endpoint<OAuthRequest>,
+        WebError: From<E::Error>;
+
+    /// Turn an OAuthOperation into a Message to send to an actor
+    fn wrap<Extras>(self, extras: Extras) -> OAuthMessage<Self, Extras> {
+        OAuthMessage(self, extras)
+    }
+}
+
+/// A message type to easily send `OAuthOperation`s to an actor
+pub struct OAuthMessage<Operation, Extras>(Operation, Extras);
+
+#[derive(Clone, Debug)]
+/// Type implementing `WebRequest` as well as `FromRequest` for use in route handlers
+///
+/// This type consumes the body of the HttpRequest upon extraction, so be careful not to use it in
+/// places you also expect an application payload
+pub struct OAuthRequest {
+    auth: Option<String>,
+    query: Option<NormalizedParameter>,
+    body: Option<NormalizedParameter>,
+}
+
+impl OAuthResponse {
+    /// Get the headers from `OAuthResponse`
+    pub fn get_headers(&self) -> HeaderMap {
+        self.headers.clone()
+    }
+
+    /// Get the body from `OAuthResponse`
+    pub fn get_body(&self) -> Option<String> {
+        self.body.clone()
+    }
+}
+
+/// Type implementing `WebRequest` as well as `FromRequest` for use in guarding resources
+///
+/// This is useful over [OAuthRequest] since [OAuthResource] doesn't consume the body of the
+/// request upon extraction
+pub struct OAuthResource {
+    auth: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+/// Type implementing `WebResponse` and `Responder` for use in route handlers
+pub struct OAuthResponse {
+    status: StatusCode,
+    headers: HeaderMap,
+    body: Option<String>,
+}
+
+#[derive(Debug)]
+/// The error type for Oxide Auth operations
+pub enum WebError {
+    /// Errors occuring in Endpoint operations
+    Endpoint(OAuthError),
+
+    /// Errors occuring when producing Headers
+    Header(InvalidHeaderValue),
+
+    /// Errors with the request encoding
+    Encoding,
+
+    /// Request body could not be parsed as a form
+    Form,
+
+    /// Request query was absent or could not be parsed
+    Query,
+
+    /// Request was missing a body
+    Body,
+
+    /// The Authorization header was invalid
+    Authorization,
+
+    /// Processing part of the request was canceled
+    Canceled,
+
+    /// An actor's mailbox was full
+    Mailbox,
+
+    /// General internal server error
+    InternalError(Option<String>),
+}
+
+impl OAuthRequest {
+    /// Create a new OAuthRequest from an HttpRequest and Payload
+    pub async fn new(req: HttpRequest, mut payload: Payload) -> Result<Self, WebError> {
+        let query = Query::extract(&req)
+            .await
+            .ok()
+            .map(|q: Query<NormalizedParameter>| q.into_inner());
+        let body = Form::from_request(&req, &mut payload)
+            .await
+            .ok()
+            .map(|b: Form<NormalizedParameter>| b.into_inner());
+
+        let mut all_auth = req.headers().get_all(header::AUTHORIZATION);
+        let optional = all_auth.next();
+
+        let auth = if all_auth.next().is_some() {
+            return Err(WebError::Authorization);
+        } else {
+            optional.and_then(|hv| hv.to_str().ok().map(str::to_owned))
+        };
+
+        Ok(OAuthRequest { auth, query, body })
+    }
+
+    /// Fetch the authorization header from the request
+    pub fn authorization_header(&self) -> Option<&str> {
+        self.auth.as_deref()
+    }
+
+    /// Fetch the query for this request
+    pub fn query(&self) -> Option<&NormalizedParameter> {
+        self.query.as_ref()
+    }
+
+    /// Fetch the query mutably
+    pub fn query_mut(&mut self) -> Option<&mut NormalizedParameter> {
+        self.query.as_mut()
+    }
+
+    /// Fetch the body of the request
+    pub fn body(&self) -> Option<&NormalizedParameter> {
+        self.body.as_ref()
+    }
+}
+
+impl OAuthResource {
+    /// Create a new OAuthResource from an HttpRequest
+    pub fn new(req: &HttpRequest) -> Result<Self, WebError> {
+        let mut all_auth = req.headers().get_all(header::AUTHORIZATION);
+        let optional = all_auth.next();
+
+        let auth = if all_auth.next().is_some() {
+            return Err(WebError::Authorization);
+        } else {
+            optional.and_then(|hv| hv.to_str().ok().map(str::to_owned))
+        };
+
+        Ok(OAuthResource { auth })
+    }
+
+    /// Turn this OAuthResource into an OAuthRequest for processing
+    pub fn into_request(self) -> OAuthRequest {
+        OAuthRequest {
+            query: None,
+            body: None,
+            auth: self.auth,
+        }
+    }
+}
+
+impl OAuthResponse {
+    /// Create a simple response with no body and a '200 OK' HTTP Status
+    pub fn ok() -> Self {
+        OAuthResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: None,
+        }
+    }
+
+    /// Set the `ContentType` header on a response
+    pub fn content_type(mut self, content_type: &str) -> Result<Self, WebError> {
+        self.headers
+            .insert(header::CONTENT_TYPE, TryFrom::try_from(content_type)?);
+        Ok(self)
+    }
+
+    /// Set the bodyfor the response
+    pub fn body(mut self, body: &str) -> Self {
+        self.body = Some(body.to_owned());
+        self
+    }
+}
+
+impl<Operation, Extras> OAuthMessage<Operation, Extras> {
+    /// Produce an OAuthOperation from a wrapping OAuthMessage
+    pub fn into_inner(self) -> (Operation, Extras) {
+        (self.0, self.1)
+    }
+}
+
+impl WebRequest for OAuthRequest {
+    type Error = WebError;
+    type Response = OAuthResponse;
+
+    fn query(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+        self.query
+            .as_ref()
+            .map(|q| Cow::Borrowed(q as &dyn QueryParameter))
+            .ok_or(WebError::Query)
+    }
+
+    fn urlbody(&mut self) -> Result<Cow<dyn QueryParameter + 'static>, Self::Error> {
+        self.body
+            .as_ref()
+            .map(|b| Cow::Borrowed(b as &dyn QueryParameter))
+            .ok_or(WebError::Body)
+    }
+
+    fn authheader(&mut self) -> Result<Option<Cow<str>>, Self::Error> {
+        Ok(self.auth.as_deref().map(Cow::Borrowed))
+    }
+}
+
+impl WebResponse for OAuthResponse {
+    type Error = WebError;
+
+    fn ok(&mut self) -> Result<(), Self::Error> {
+        self.status = StatusCode::OK;
+        Ok(())
+    }
+
+    fn redirect(&mut self, url: Url) -> Result<(), Self::Error> {
+        self.status = StatusCode::FOUND;
+        let location = String::from(url);
+        self.headers
+            .insert(header::LOCATION, TryFrom::try_from(location)?);
+        Ok(())
+    }
+
+    fn client_error(&mut self) -> Result<(), Self::Error> {
+        self.status = StatusCode::BAD_REQUEST;
+        Ok(())
+    }
+
+    fn unauthorized(&mut self, kind: &str) -> Result<(), Self::Error> {
+        self.status = StatusCode::UNAUTHORIZED;
+        self.headers
+            .insert(header::WWW_AUTHENTICATE, TryFrom::try_from(kind)?);
+        Ok(())
+    }
+
+    fn body_text(&mut self, text: &str) -> Result<(), Self::Error> {
+        self.body = Some(text.to_owned());
+        self.headers
+            .insert(header::CONTENT_TYPE, TryFrom::try_from("text/plain")?);
+        Ok(())
+    }
+
+    fn body_json(&mut self, json: &str) -> Result<(), Self::Error> {
+        self.body = Some(json.to_owned());
+        self.headers
+            .insert(header::CONTENT_TYPE, TryFrom::try_from("application/json")?);
+        Ok(())
+    }
+}
+
+impl<Operation, Extras> Message for OAuthMessage<Operation, Extras>
+where
+    Operation: OAuthOperation + 'static,
+{
+    type Result = Result<Operation::Item, Operation::Error>;
+}
+
+impl FromRequest for OAuthRequest {
+    type Error = WebError;
+    type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        Self::new(req.clone(), payload.take()).boxed_local()
+    }
+}
+
+impl FromRequest for OAuthResource {
+    type Error = WebError;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
+        future::ready(Self::new(req))
+    }
+}
+
+impl Responder for OAuthResponse {
+    type Body = BoxBody;
+
+    fn respond_to(self, _: &HttpRequest) -> HttpResponse {
+        let mut builder = HttpResponseBuilder::new(self.status);
+        for (k, v) in self.headers.into_iter() {
+            builder.insert_header((k, v.to_owned()));
+        }
+
+        if let Some(body) = self.body {
+            builder.body(body)
+        } else {
+            builder.finish()
+        }
+    }
+}
+
+impl From<OAuthResource> for OAuthRequest {
+    fn from(o: OAuthResource) -> Self {
+        o.into_request()
+    }
+}
+
+impl Default for OAuthResponse {
+    fn default() -> Self {
+        OAuthResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: None,
+        }
+    }
+}
+
+impl From<Error<OAuthRequest>> for WebError {
+    fn from(e: Error<OAuthRequest>) -> Self {
+        match e {
+            Error::Web(e) => e,
+            Error::OAuth(e) => e.into(),
+        }
+    }
+}
+
+impl From<InvalidHeaderValue> for WebError {
+    fn from(e: InvalidHeaderValue) -> Self {
+        WebError::Header(e)
+    }
+}
+
+impl From<MailboxError> for WebError {
+    fn from(e: MailboxError) -> Self {
+        match e {
+            MailboxError::Closed => WebError::Mailbox,
+            MailboxError::Timeout => WebError::Canceled,
+        }
+    }
+}
+
+impl From<OAuthError> for WebError {
+    fn from(e: OAuthError) -> Self {
+        WebError::Endpoint(e)
+    }
+}
+
+impl fmt::Display for WebError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            WebError::Endpoint(ref e) => write!(f, "Endpoint, {}", e),
+            WebError::Header(ref e) => write!(f, "Couldn't set header, {}", e),
+            WebError::Encoding => write!(f, "Error decoding request"),
+            WebError::Form => write!(f, "Request is not a form"),
+            WebError::Query => write!(f, "No query present"),
+            WebError::Body => write!(f, "No body present"),
+            WebError::Authorization => write!(f, "Request has invalid Authorization headers"),
+            WebError::Canceled => write!(f, "Operation canceled"),
+            WebError::Mailbox => write!(f, "An actor's mailbox was full"),
+            WebError::InternalError(None) => write!(f, "An internal server error occured"),
+            WebError::InternalError(Some(ref e)) => write!(f, "An internal server error occured: {}", e),
+        }
+    }
+}
+
+impl error::Error for WebError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            WebError::Endpoint(ref e) => e.source(),
+            WebError::Header(ref e) => e.source(),
+            WebError::Encoding
+            | WebError::Form
+            | WebError::Authorization
+            | WebError::Query
+            | WebError::Body
+            | WebError::Canceled
+            | WebError::Mailbox
+            | WebError::InternalError(_) => None,
+        }
+    }
+}
+
+impl ResponseError for WebError {
+    // Default to 500 for now
+}

--- a/src/api/oauth2/prelude.rs
+++ b/src/api/oauth2/prelude.rs
@@ -1,0 +1,12 @@
+use oxide_auth::primitives::scope::{ParseScopeErr, Scope};
+use crate::auth::JwtTokenScope;
+
+impl JwtTokenScope {
+    pub fn into_oauth_scope(self) -> Result<Scope, ParseScopeErr> {
+        let scope_name = match self {
+            JwtTokenScope::Full => "full",
+            JwtTokenScope::Profile => "profile",
+        };
+        scope_name.parse()
+    }
+}

--- a/src/api/oauth2/state.rs
+++ b/src/api/oauth2/state.rs
@@ -15,7 +15,6 @@ use crate::api::oauth2::oxide_auth_actix::{
 use crate::api::oauth2::token_issuer::JwtTokenIssuer;
 use crate::auth::JwtTokenScope;
 use crate::config::Config;
-use crate::db::models::user::User;
 
 pub struct OAuth2State {
     endpoint: Generic<
@@ -31,7 +30,7 @@ pub struct OAuth2State {
 #[derive(Debug, Clone)]
 pub enum Extras {
     AuthGet,
-    AuthPost(User, OAuth2AuthorizationResult),
+    AuthPost(String, OAuth2AuthorizationResult),
     ClientCredentials,
     Nothing,
 }
@@ -143,10 +142,10 @@ where
 
                 op.run(self.with_solicitor(solicitor))
             },
-            Extras::AuthPost(user, result) => {
+            Extras::AuthPost(user_id, result) => {
                 let solicitor = FnSolicitor(move |_: &mut OAuthRequest, _: Solicitation| {
                     match result {
-                        OAuth2AuthorizationResult::Allow => OwnerConsent::Authorized(user.id.to_string()),
+                        OAuth2AuthorizationResult::Allow => OwnerConsent::Authorized(user_id.clone()),
                         _ => OwnerConsent::Denied
                     }
                 });

--- a/src/api/oauth2/state.rs
+++ b/src/api/oauth2/state.rs
@@ -1,0 +1,175 @@
+use std::fs;
+
+use actix::{Actor, Context, Handler};
+use oxide_auth::{
+    endpoint::{Endpoint, OwnerConsent, OwnerSolicitor, Solicitation, WebResponse},
+    frontends::simple::endpoint::{ErrorInto, FnSolicitor, Generic, Vacant},
+    primitives::prelude::{AuthMap, ClientMap, RandomGenerator, Scope},
+};
+
+use crate::api::models::oauth2::OAuth2AuthorizationResult;
+use crate::api::oauth2::config::OAuthConfig;
+use crate::api::oauth2::oxide_auth_actix::{
+    OAuthMessage, OAuthOperation, OAuthRequest, OAuthResponse, WebError
+};
+use crate::api::oauth2::token_issuer::JwtTokenIssuer;
+use crate::auth::JwtTokenScope;
+use crate::config::Config;
+use crate::db::models::user::User;
+
+pub struct OAuth2State {
+    endpoint: Generic<
+        ClientMap,
+        AuthMap<RandomGenerator>,
+        JwtTokenIssuer,
+        Vacant,
+        Vec<Scope>,
+        fn() -> OAuthResponse,
+    >,
+}
+
+#[derive(Debug, Clone)]
+pub enum Extras {
+    AuthGet,
+    AuthPost(User, OAuth2AuthorizationResult),
+    ClientCredentials,
+    Nothing,
+}
+
+impl OAuth2State {
+    pub fn preconfigured(config: Config) -> Self {
+        let jwt_issuer = JwtTokenIssuer::new(config.clone());
+
+        let oauth_config = match fs::read_to_string(&config.oauth_config_path) {
+            Ok(oauth_config_toml_string) => toml::from_str::<OAuthConfig>(&oauth_config_toml_string)
+                .map_err(|e| {
+                    log::error!("Failed to read oauth configuration: {:?}", e)
+                })
+                .ok(),
+            Err(e) => {
+                log::warn!("Couldn't load oauth config from path {}: {:?}", &config.oauth_config_path, e);
+                None
+            }
+        };
+
+        OAuth2State {
+            endpoint: Generic {
+                // A registrar with one pre-registered client
+                registrar: oauth_config.map_or(ClientMap::default(), |config|
+                    config.clients.iter().map(|c| c.into()).collect()
+                ),
+                // Authorization tokens are 16 byte random keys to a memory hash map.
+                authorizer: AuthMap::new(RandomGenerator::new(16)),
+                // Bearer tokens are also random generated but 256-bit tokens, since they live longer
+                // and this example is somewhat paranoid.
+                //
+                // We could also use a `TokenSigner::ephemeral` here to create signed tokens which can
+                // be read and parsed by anyone, but not maliciously created. However, they can not be
+                // revoked and thus don't offer even longer lived refresh tokens.
+                issuer: jwt_issuer,
+
+                solicitor: Vacant,
+
+                // scopes: vec![],
+                scopes: vec![JwtTokenScope::Profile.into_oauth_scope().unwrap()],
+
+                response: OAuthResponse::ok,
+            },
+        }
+    }
+
+    pub fn with_solicitor<'a, S>(
+        &'a mut self, solicitor: S,
+    ) -> impl Endpoint<OAuthRequest, Error = WebError> + 'a
+    where
+        S: OwnerSolicitor<OAuthRequest> + 'static,
+    {
+        ErrorInto::new(Generic {
+            authorizer: &mut self.endpoint.authorizer,
+            registrar: &mut self.endpoint.registrar,
+            issuer: &mut self.endpoint.issuer,
+            solicitor,
+            scopes: &mut self.endpoint.scopes,
+            response: OAuthResponse::ok,
+        })
+    }
+}
+
+impl Actor for OAuth2State {
+    type Context = Context<Self>;
+}
+
+impl<Operation> Handler<OAuthMessage<Operation, Extras>> for OAuth2State
+where
+    Operation: OAuthOperation,
+{
+    type Result = Result<Operation::Item, Operation::Error>;
+
+    fn handle(&mut self, msg: OAuthMessage<Operation, Extras>, _: &mut Self::Context) -> Self::Result {
+        let (op, ex) = msg.into_inner();
+        match ex {
+            Extras::AuthGet => {
+                let solicitor = FnSolicitor(move |_: &mut OAuthRequest, solicitation: Solicitation| {
+                    let grant = solicitation.pre_grant();
+                    let state = solicitation.state();
+
+                    let scope = grant.scope.to_string();
+                    let mut extra = vec![
+                        ("response_type", "code"),
+                        ("client_id", grant.client_id.as_str()),
+                        ("redirect_uri", grant.redirect_uri.as_str()),
+                        ("scope", &scope),
+                    ];
+
+                    if let Some(state) = state {
+                        extra.push(("state", state));
+                    }
+
+                    let public_url = std::env::var("PUBLIC_URL").unwrap();
+                    let redirect_url = url::Url::parse_with_params(
+                        &format!("{}/auth/authorize", &public_url), &extra
+                    )
+                    .unwrap();
+
+                    let mut response = OAuthResponse::ok();
+                    response.redirect(redirect_url)
+                        .map_err(|_| WebError::InternalError(Some("Failed to redirect".to_string())))
+                        .unwrap();
+
+                    // This will display a page to the user asking for his permission to proceed. The submitted form
+                    // will then trigger the other authorization handler which actually completes the flow.
+                    OwnerConsent::InProgress(response)
+                });
+
+                op.run(self.with_solicitor(solicitor))
+            },
+            Extras::AuthPost(user, result) => {
+                let solicitor = FnSolicitor(move |_: &mut OAuthRequest, _: Solicitation| {
+                    match result {
+                        OAuth2AuthorizationResult::Allow => OwnerConsent::Authorized(user.id.to_string()),
+                        _ => OwnerConsent::Denied
+                    }
+                });
+
+                op.run(self.with_solicitor(solicitor))
+            },
+            // Extras::ClientCredentials => {
+            //     let solicitor = FnSolicitor(move |request: &mut OAuthRequest, solicitation: Solicitation| {
+            //         // For the client credentials flow, the solicitor is consulted
+            //         // to ensure that the resulting access token is issued to the
+            //         // correct owner. This may be the client itself, if clients
+            //         // and resource owners are from the same set of entities, but
+            //         // may be distinct if that is not the case.
+            //         OwnerConsent::Authorized(solicitation.pre_grant().client_id.clone())
+            //     });
+            //
+            //     op.run(self.with_solicitor(solicitor))
+            // },
+            Extras::Nothing => {
+                let result = op.run(&mut self.endpoint);
+                result
+            },
+            _ => op.run(&mut self.endpoint),
+        }
+    }
+}

--- a/src/api/oauth2/token_issuer.rs
+++ b/src/api/oauth2/token_issuer.rs
@@ -1,0 +1,49 @@
+use std::ops::Add;
+use chrono::Utc;
+use oxide_auth::endpoint::Issuer;
+use oxide_auth::primitives::grant::Grant;
+use oxide_auth::primitives::issuer::{IssuedToken, RefreshedToken, TokenType};
+use crate::auth::{create_jwt_token, JwtTokenScope, JwtTokenType};
+use crate::config::Config;
+
+pub struct JwtTokenIssuer {
+    config: Config,
+}
+
+impl JwtTokenIssuer {
+    pub fn new(config: Config) -> JwtTokenIssuer {
+        JwtTokenIssuer { config }
+    }
+}
+
+impl Issuer for JwtTokenIssuer {
+    fn issue(&mut self, grant: Grant) -> Result<IssuedToken, ()> {
+        let token = create_jwt_token(&grant.owner_id, JwtTokenType::Access, &JwtTokenScope::Profile, &self.config)
+            .map_err(|e| {
+                log::error!("Failed to create oauth access token for user {}: {:?}", &grant.owner_id, e)
+            })?;
+        let refresh = create_jwt_token(&grant.owner_id, JwtTokenType::Refresh, &JwtTokenScope::Profile, &self.config)
+            .map_err(|e|
+                log::error!("Failed to create oauth access token for user {}: {:?}", &grant.owner_id, e)
+            )?;
+
+        Ok(IssuedToken {
+            token,
+            refresh: Some(refresh),
+            until: Utc::now().add(chrono::Duration::seconds(self.config.jwt_expiration)),
+            token_type: TokenType::Bearer,
+        })
+    }
+
+    fn refresh(&mut self, _refresh: &str, _grant: Grant) -> Result<RefreshedToken, ()> {
+        Err(())
+    }
+
+    fn recover_token<'a>(&'a self, _: &'a str) -> Result<Option<Grant>, ()> {
+        Err(())
+    }
+
+    fn recover_refresh<'a>(&'a self, _: &'a str) -> Result<Option<Grant>, ()> {
+        Err(())
+    }
+}

--- a/src/api/oauth2_controller.rs
+++ b/src/api/oauth2_controller.rs
@@ -1,0 +1,79 @@
+use std::ops::Deref;
+
+use actix::Addr;
+use actix_web::web;
+use oxide_auth::endpoint::{QueryParameter, WebResponse};
+
+use crate::{api::oauth2::state::OAuth2State, AppState, middlewares::auth::JwtMiddleware};
+use crate::api::models::oauth2::{OAuth2AuthorizationResult, OAuthRedirectResponse};
+use crate::api::utils::enforce_scope;
+use crate::auth::JwtTokenScope;
+use crate::services::auth_service;
+
+use super::oauth2::oxide_auth_actix::{Authorize, ClientCredentials, OAuthOperation, OAuthRequest, OAuthResponse, Refresh, Token, WebError};
+use super::oauth2::state::Extras;
+
+pub async fn get_authorize(req: OAuthRequest, state: web::Data<Addr<OAuth2State>>) -> Result<OAuthResponse, WebError> {
+    state.send(Authorize(req)
+        .wrap(Extras::AuthGet))
+        .await?
+}
+
+pub async fn post_authorize(req: OAuthRequest, state: web::Data<Addr<OAuth2State>>, data: web::Data<AppState>, jwt: JwtMiddleware) -> Result<OAuthResponse, WebError> {
+    enforce_scope(&jwt, JwtTokenScope::Full).map_err(|e| WebError::Authorization)?;
+
+    let user = auth_service::user_details(&data.db, jwt.user_id).map_err(|e| WebError::Authorization)?;
+
+    let result_string = req.query()
+        .and_then(|q| q.unique_value("result"))
+        .ok_or(WebError::Query)?;
+
+    let result = match result_string.deref() {
+        "allow" => Ok(OAuth2AuthorizationResult::Allow),
+        "deny" => Ok(OAuth2AuthorizationResult::Deny),
+        _ => Err(WebError::Query),
+    }?;
+
+    let response = state.send(Authorize(req)
+        .wrap(Extras::AuthPost(user, result)))
+        .await?;
+
+    match response {
+        Ok(r) => {
+            let headers = r.get_headers();
+            let location = headers.get("location");
+            if let Some(redirect_url) = location {
+                let body = serde_json::to_string(&OAuthRedirectResponse {
+                    redirect_url: redirect_url.to_str().unwrap().to_string()
+                }).unwrap();
+                let mut modified_response = OAuthResponse::ok();
+                _ = modified_response.body_json(&body);
+                Ok(modified_response)
+            } else {
+                Ok(r)
+            }
+        },
+        Err(e) => Err(e)
+    }
+}
+
+pub async fn token(req: OAuthRequest, state: web::Data<Addr<OAuth2State>>) -> Result<OAuthResponse, WebError> {
+    let grant_type = req.body().and_then(|body| body.unique_value("grant_type"));
+
+    match grant_type.as_deref() {
+        Some("client_credentials") => {
+            state
+                .send(ClientCredentials(req).wrap(Extras::ClientCredentials))
+                .await?
+        },
+        // Each flow will validate the grant_type again, so we can let one case handle
+        // any incorrect or unsupported options.
+        _ => state.send(Token(req).wrap(Extras::Nothing)).await?,
+    }
+}
+
+async fn refresh(
+    (req, state): (OAuthRequest, web::Data<Addr<OAuth2State>>),
+) -> Result<OAuthResponse, WebError> {
+    state.send(Refresh(req).wrap(Extras::Nothing)).await?
+}

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -1,0 +1,11 @@
+use crate::auth::JwtTokenScope;
+use crate::errors::ServiceError;
+use crate::middlewares::auth::JwtMiddleware;
+
+pub fn enforce_scope(jwt: &JwtMiddleware, scope: JwtTokenScope) -> Result<(), ServiceError> {
+    if jwt.scope > scope {
+        Err(ServiceError::Unauthorized { error_message: "Invalid token scope.".to_string() })
+    } else {
+        Ok(())
+    }
+}

--- a/src/config/app.rs
+++ b/src/config/app.rs
@@ -24,6 +24,17 @@ pub fn config_services(cfg: &mut web::ServiceConfig) {
                     )
                     .service(
                         web::resource("/me").route(web::get().to(auth_controller::me)),
+                    )
+                    .service(
+                        web::scope("/oauth2")
+                            .service(
+                                web::resource("/authorize")
+                                    .route(web::get().to(oauth2_controller::get_authorize))
+                                    .route(web::post().to(oauth2_controller::post_authorize)),
+                            )
+                            .service(
+                                web::resource("/token").route(web::post().to(oauth2_controller::token)),
+                            )
                     ),
             )
             .service(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,4 @@
-use crate::constants::{DEFAULT_JWT_EXPIRATION, DEFAULT_JWT_REFRESH_EXPIRATION};
+use crate::constants::{DEFAULT_JWT_EXPIRATION, DEFAULT_JWT_REFRESH_EXPIRATION, DEFAULT_OAUTH_CONFIG_PATH};
 
 pub mod app;
 pub mod db;
@@ -13,8 +13,10 @@ pub struct Config {
     pub jwt_expiration: i64,
     pub jwt_refresh_expiration: i64,
     pub cors_origin: String,
+    pub public_url: String,
     pub database_url: String,
     pub storage_path: String,
+    pub oauth_config_path: String,
 }
 
 impl Config {
@@ -36,8 +38,12 @@ impl Config {
             Err(_) => DEFAULT_JWT_REFRESH_EXPIRATION,
         };
         let cors_origin = std::env::var("CORS_ORIGIN").expect("CORS_ORIGIN must be set");
+        let public_url = std::env::var("PUBLIC_URL").expect("PUBLIC_URL must be set");
         let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
         let storage_path = std::env::var("STORAGE_PATH").expect("STORAGE_PATH must be set");
+
+        let oauth_config_path = std::env::var("OAUTH_CONFIG_PATH")
+            .unwrap_or(DEFAULT_OAUTH_CONFIG_PATH.to_string());
 
         Config {
             // secret_key,
@@ -48,8 +54,10 @@ impl Config {
             jwt_expiration,
             jwt_refresh_expiration,
             cors_origin,
+            public_url,
             database_url,
             storage_path,
+            oauth_config_path,
         }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,6 +3,7 @@ pub const DEFAULT_JWT_REFRESH_EXPIRATION: i64 = 3600*24*7;
 pub const DEFAULT_OAUTH_CONFIG_PATH: &str = "/config/oauth_config.toml";
 
 pub const REFRESH_API_PATH: &str = "/api/auth/refresh";
+pub const OAUTH_GET_API_PATH: &str = "/api/auth/oauth2/authorize";
 pub const UNPROTECTED_API_PATHS: [&str; 4] = [
     "/api/health",
     "/api/auth/signup",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 pub const DEFAULT_JWT_EXPIRATION: i64 = 3600;
 pub const DEFAULT_JWT_REFRESH_EXPIRATION: i64 = 3600*24*7;
+pub const DEFAULT_OAUTH_CONFIG_PATH: &str = "/config/oauth_config.toml";
 
 pub const REFRESH_API_PATH: &str = "/api/auth/refresh";
 pub const UNPROTECTED_API_PATHS: [&str; 4] = [

--- a/src/db/models/mod.rs
+++ b/src/db/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod user;
+pub mod oauth_authorization;
 pub mod app_review;
 
 use diesel::result::Error;

--- a/src/db/models/oauth_authorization.rs
+++ b/src/db/models/oauth_authorization.rs
@@ -1,0 +1,89 @@
+use std::ops::Deref;
+
+use chrono::{NaiveDateTime, Utc};
+use diesel::prelude::*;
+use diesel::result::Error;
+use serde::{Deserialize, Serialize};
+
+use crate::db::Connection;
+use crate::db::models::user::User;
+use crate::db::schema::oauth_authorizations;
+
+#[derive(Identifiable, Insertable, Associations, Queryable, Selectable, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[diesel(belongs_to(User))]
+#[diesel(primary_key(user_id, client_id))]
+#[diesel(table_name = oauth_authorizations)]
+pub struct OAuthAuthorization {
+    pub user_id: String,
+    pub client_id: String,
+    #[serde(skip_serializing)]
+    pub created_at: NaiveDateTime,
+    #[serde(skip_serializing)]
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UserDTO {
+    pub user_id: String,
+    pub client_id: String,
+}
+
+impl OAuthAuthorization {
+    pub fn new(user: &User, client_id: &str) -> Self {
+        let now = Utc::now().naive_utc();
+
+        Self {
+            user_id: user.id.to_string(),
+            client_id: client_id.to_string(),
+
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+impl OAuthAuthorization {
+    pub fn insert(&mut self, conn: &mut Connection) -> Result<(), Error> {
+        diesel::insert_into(oauth_authorizations::dsl::oauth_authorizations)
+            .values(self.deref())
+            .execute(conn)
+            .map(|_| ())
+    }
+
+    pub fn delete(&mut self, conn: &mut Connection) -> Result<(), Error> {
+        diesel::delete(self.deref())
+            .execute(conn)
+            .map(|_| ())
+    }
+}
+
+impl User {
+    pub fn authorization_for_oauth_client(&self, client_id: &str, conn: &mut Connection) -> Option<OAuthAuthorization> {
+        OAuthAuthorization::belonging_to(self)
+            .select(OAuthAuthorization::as_select())
+            .filter(oauth_authorizations::client_id.eq(client_id))
+            .first(conn)
+            .ok()
+    }
+
+    pub fn has_authorized_oauth_client(&self, client_id: &str, conn: &mut Connection) -> bool {
+        self.authorization_for_oauth_client(client_id, conn).is_some()
+    }
+
+    pub fn save_oauth_client_authorization(&mut self, client_id: &str, conn: &mut Connection) -> Result<(), Error> {
+        if self.has_authorized_oauth_client(client_id, conn) {
+            return Ok(())
+        }
+
+        OAuthAuthorization::new(&self, client_id)
+            .insert(conn)
+    }
+
+    pub fn remove_oauth_client_authorization(&mut self, client_id: &str, conn: &mut Connection) -> Result<(), Error> {
+        if let Some(mut authorization) = self.authorization_for_oauth_client(client_id, conn) {
+            authorization.delete(conn)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -11,8 +11,9 @@ use crate::db::schema::users;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Queryable, Insertable, AsChangeset, ToResponse)]
 #[diesel(table_name = users)]
+#[serde(rename_all = "camelCase")]
 pub struct User {
-    #[serde(default, skip_serializing)]
+    #[serde(default)]
     pub id: String,
     pub email: String,
     pub username: Option<String>,

--- a/src/db/models/user.rs
+++ b/src/db/models/user.rs
@@ -1,7 +1,7 @@
 use log::error;
 use chrono::{Utc, NaiveDateTime};
 use serde::{Deserialize, Serialize};
-use diesel::{Queryable, Insertable, AsChangeset, RunQueryDsl, QueryDsl, ExpressionMethods};
+use diesel::prelude::*;
 use diesel::result::Error;
 use utoipa::ToResponse;
 
@@ -9,7 +9,7 @@ use crate::db::Connection;
 use crate::db::schema::users;
 
 
-#[derive(Serialize, Deserialize, Debug, Clone, Queryable, Insertable, AsChangeset, ToResponse)]
+#[derive(Serialize, Deserialize, Debug, Clone, Queryable, Identifiable, Insertable, AsChangeset, ToResponse)]
 #[diesel(table_name = users)]
 #[serde(rename_all = "camelCase")]
 pub struct User {

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -2,14 +2,21 @@
 
 diesel::table! {
     app_review_signatures (id) {
+        #[max_length = 255]
         id -> Varchar,
+        #[max_length = 255]
         user_id -> Varchar,
+        #[max_length = 255]
         status -> Varchar,
         sequence_number -> Int4,
+        #[max_length = 255]
         source_id -> Varchar,
+        #[max_length = 255]
         app_bundle_id -> Varchar,
+        #[max_length = 255]
         app_version -> Nullable<Varchar>,
         review_rating -> Nullable<Int4>,
+        #[max_length = 255]
         signature -> Nullable<Varchar>,
         created_at -> Timestamp,
         updated_at -> Timestamp,
@@ -17,10 +24,25 @@ diesel::table! {
 }
 
 diesel::table! {
+    oauth_authorizations (user_id, client_id) {
+        #[max_length = 255]
+        user_id -> Varchar,
+        #[max_length = 255]
+        client_id -> Varchar,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     users (id) {
+        #[max_length = 255]
         id -> Varchar,
+        #[max_length = 255]
         email -> Varchar,
+        #[max_length = 255]
         username -> Nullable<Varchar>,
+        #[max_length = 255]
         password_hash -> Varchar,
         created_at -> Timestamp,
         updated_at -> Timestamp,
@@ -28,8 +50,10 @@ diesel::table! {
 }
 
 diesel::joinable!(app_review_signatures -> users (user_id));
+diesel::joinable!(oauth_authorizations -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     app_review_signatures,
+    oauth_authorizations,
     users,
 );

--- a/src/services/auth_service.rs
+++ b/src/services/auth_service.rs
@@ -1,4 +1,4 @@
-use crate::auth::create_auth_tokens;
+use crate::auth::{create_auth_tokens, JwtTokenScope};
 use crate::config::Config;
 use crate::db::Pool;
 use crate::db::models::user::{User, UserDTO};
@@ -21,7 +21,7 @@ pub fn signup(user_dto: UserDTO, pool: &Pool, config: &Config) -> Result<UserAnd
         Err(_) => return Err(ServiceError::InternalServerError { error_message: "User could not be saved".to_string() })
     };
 
-    let (access_token, refresh_token) = match create_auth_tokens(&user, config) {
+    let (access_token, refresh_token) = match create_auth_tokens(&user, config, JwtTokenScope::Full) {
         Ok(tokens) => tokens,
         Err(e) => return Err(ServiceError::InternalServerError { error_message: e })
     };
@@ -43,7 +43,7 @@ pub fn login(user_dto: UserDTO, pool: &Pool, config: &Config) -> Result<UserAndT
         return Err(ServiceError::Unauthorized { error_message: "Password is incorrect".to_string() })
     }
 
-    let (access_token, refresh_token) = match create_auth_tokens(&user, config) {
+    let (access_token, refresh_token) = match create_auth_tokens(&user, config, JwtTokenScope::Full) {
         Ok(tokens) => tokens,
         Err(e) => return Err(ServiceError::InternalServerError { error_message: e })
     };
@@ -59,7 +59,7 @@ pub fn refresh(pool: &Pool, config: &Config, user_id: uuid::Uuid) -> Result<User
         Err(_) => return Err(ServiceError::Unauthorized { error_message: "User not found".to_string() })
     };
 
-    let (access_token, refresh_token) = match create_auth_tokens(&user, config) {
+    let (access_token, refresh_token) = match create_auth_tokens(&user, config, JwtTokenScope::Full) {
         Ok(tokens) => tokens,
         Err(e) => return Err(ServiceError::InternalServerError { error_message: e })
     };


### PR DESCRIPTION
This PR adds endpoints for other services to use SideStore ID as an external authorization provider with the OAuth protocol.

Due to some issues with `oxide-auth-actix`, most of it's source code is included in this merge request rather than importing it from the `oxide-auth-actix` crate.